### PR TITLE
Include pencil_lib.h from pencil_compat.h

### DIFF
--- a/include/pencil.h
+++ b/include/pencil.h
@@ -52,8 +52,5 @@
 /* PENCIL to C compatibility layer. */
 #include "pencil_compat.h"
 
-/* PENCIL built-in functions prototypes and (possible) implementations. */
-#include "pencil_lib.h"
-
 #endif
 #endif

--- a/include/pencil_compat.h
+++ b/include/pencil_compat.h
@@ -45,4 +45,7 @@
 /* bool */
 #include <stdbool.h>
 
+/* PENCIL built-in functions prototypes and (possible) implementations. */
+#include "pencil_lib.h"
+
 #endif


### PR DESCRIPTION
Suggested by Albert.  Having only one header file for the PENCIL
compatibility mode is better than having two files (in case a user wants
only to use PENCIL in compatibility mode, i.e. to compile his code with
a standard C compiler).  This patch includes the automatically
generated pencil_lib.h file in pencil_compat.h so that the user
does not need to think about including both.
